### PR TITLE
Remove Bootstrap and unused JS libraries from stack theme

### DIFF
--- a/resources/views/footer.blade.php
+++ b/resources/views/footer.blade.php
@@ -1,3 +1,2 @@
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Bootstrap demo</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-  
+    <!-- Removed Bootstrap CSS include -->
   </head>
 
   <body>

--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -5,10 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>De Blauwe Vogel Themadagen - @yield('title')</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-  <link rel="icon" href="{{asset('favicon.ico')}}">
-  <link href="{{asset('style.css')}}" rel="stylesheet"></head>
+    <link rel="icon" href="{{asset('favicon.ico')}}">
+    <link href="{{asset('style.css')}}" rel="stylesheet"></head>
   <body
     x-data="{ page: 'blog-single', 'darkMode': true, 'stickyMenu': false, 'navigationOpen': false, 'scrollTop': false }"
     x-init="


### PR DESCRIPTION
This PR removes Bootstrap CSS/JS includes from Blade templates as the stack uses Tailwind and Alpine. Further cleanup of unused JS libraries can be done if required.